### PR TITLE
Link with crypto to avoid linking error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS += -Wall -g
-LDFLAGS += -lssl -lpthread
+LDFLAGS += -lssl -lpthread -lcrypto
 
 TESTS = tls
 

--- a/tls.c
+++ b/tls.c
@@ -196,7 +196,6 @@ int main_tls_client() {
 
   int res = 0;
   int total_recv = 0;
-  int cnt = 0;
 
   start = clock();
 
@@ -220,7 +219,6 @@ int main_tls_client() {
 
   res = 0;
   total_recv = 0;
-  cnt = 0;
 
   res = SSL_read(ssl, buf, 1);
 
@@ -382,7 +380,6 @@ int main_tls_client() {
   res = 0;
   total_recv = 0;
 
-  cnt = 0;
   res = recv(opfd, &buf, 1, 0);
 
   total_recv += res;

--- a/tls.c
+++ b/tls.c
@@ -510,6 +510,7 @@ void *main_server(void* unused)
 
   ctx = InitServerCTX();/* initialize SSL */
   LoadCertificates(ctx, "ca.crt", "ca.pem");/* load certs */
+  SSL_CTX_set_cipher_list(ctx, "ECDH-ECDSA-AES128-GCM-SHA256");
 
   int server = OpenListener(port);/* create server socket */
   while (1)


### PR DESCRIPTION
Fixes:

```
/usr/bin/ld: /tmp/ccSFm9AX.o: undefined reference to symbol 'ERR_load_crypto_strings@@libcrypto.so.10'
/lib64/libcrypto.so.10: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:8: recipe for target 'tls' failed
make: *** [tls] Error 1

```
